### PR TITLE
Ada_Server v45.2/0-3 - Ignore the output of the Modifier (SignTool).

### DIFF
--- a/Ada/Servers/Ada_95/Ada_Server/Ada_Server.adb
+++ b/Ada/Servers/Ada_95/Ada_Server/Ada_Server.adb
@@ -5,7 +5,7 @@
 pragma Style_White_Elephant;
 
 pragma Build (Description => "Ada Server for NP++ Elephant Plugin",
-              Version     => (45, 2, 0, 2),
+              Version     => (45, 2, 0, 3),
               Kind        => Windows,
               Compiler    => "GNATPRO\23.0");
 

--- a/Ada/Servers/Ada_95/Ada_Server/Target.adb
+++ b/Ada/Servers/Ada_95/Ada_Server/Target.adb
@@ -268,8 +268,9 @@ package body Target is
       Promotion.Set_Message ("Modify " & Project.Modifier_Parameters);
       declare
         Result : constant String
-          := Strings.Trimmed (Os.Process.Execution_Of (Executable => Modifier,
-                                                       Parameters => Project.Modifier_Parameters));
+          := Strings.Trimmed (Os.Process.Execution_Of (Executable    => Modifier,
+                                                       Parameters    => Project.Modifier_Parameters,
+                                                       Handle_Output => False));
       begin
         if Result /= "" then
           Promotion.Set_Error (Result);


### PR DESCRIPTION
Ignore the output of the Modifier to avoid a promotion error.